### PR TITLE
Convert cite links with an associated node into id links

### DIFF
--- a/org-roam-ui.el
+++ b/org-roam-ui.el
@@ -153,9 +153,23 @@ This serves the web-build and API over HTTP."
 (defun org-roam-ui--send-graphdata ()
   "Get roam data, make JSON, send through websocket to org-roam-ui."
   (let* ((nodes-columns [id file title level])
-         (links-columns [source dest type])
+         (links-columns [links:source links:dest links:type refs:node-id])
          (nodes-db-rows (org-roam-db-query `[:select ,nodes-columns :from nodes]))
-         (links-db-rows (org-roam-db-query `[:select ,links-columns :from links :where (or (= type "id") (= type "cite"))]))
+         ;; Left outer join on refs means any id link (or cite link without a
+         ;; corresponding node) will have 'nil for the `refs:node-id' value. Any
+         ;; cite link where a node has that `:ROAM_REFS:' will have a value.
+         (links-db-rows (org-roam-db-query `[:select ,links-columns
+                                             :from links
+                                             :left :outer :join refs :on (= links:dest refs:ref)
+                                             :where (or (= links:type "id") (= links:type "cite"))]))
+         ;; Convert any cite links that have nodes with associated refs to a
+         ;; standard id link while removing the 'nil `refs:node-id' from all
+         ;; other links
+         (links-db-rows (seq-map (lambda (l)
+                                   (pcase-let ((`(,source ,dest ,type ,node-id) l))
+                                     (if node-id
+                                         (list source node-id "id")
+                                       (list source dest type)))) links-db-rows))
          (response `((nodes . ,(mapcar (apply-partially #'org-roam-ui-sql-to-alist (append nodes-columns nil)) nodes-db-rows))
                                   (links . ,(mapcar (apply-partially #'org-roam-ui-sql-to-alist '(source target type)) links-db-rows)))))
     (websocket-send-text oru-ws (json-encode `((type . "graphdata") (data . ,response))))))


### PR DESCRIPTION
Currently the `org-roam-ui--send-graphdata` function gets all `id` and
`cite` links from the database. They are all sent over the websocket,
but nothing is done to handle the cite links, they don't appear in the
graph. These are not handled because instead of being an (`id` `id`
`type`) tuple, they are (`id` `ref` `type`).

This change uses a join in the DB to get the `id` of the node that `ref`
is associated with. A map function applied to the list of links converts
any cite link whose `ref` has an associated node into an (`id` `id`
`type`) tuple (changing the `type` from `"cite"` to `"id"`). This new
link is correctly handled and appears in the graph.

This change is destructive, we no longer have access to the cite link
as it was in the DB. If there were plans to use this link in the UI and
cite links there, we can ignore this change. We can also not change
the link type to `id` if we want, then we would do things like different
colors for cite links in the graph.