### PR TITLE
Add basic CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,29 @@
+---
+# File : ci.yml
+
+name: "ci"
+on:
+  push:
+defaults:
+  run:
+    shell: "bash"
+jobs:
+  build:
+    name: "[ci|build]"
+    runs-on: "ubuntu-18.04"
+    steps:
+      - name: "[build|checkout] ${{ github.repository }} project"
+        uses: "actions/checkout@v2"
+        with:
+          repository: "${{ github.repository }}"
+          token: "${{ github.token }}"
+          fetch-depth: 1
+          clean: true
+          lfs: false
+          persist-credentials: false
+          submodules: false
+      - name: "[bulid]"
+        run: |
+          yarn
+...
+# End of ci.yml

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,6 +18,8 @@ jobs:
           repository: "${{ github.repository }}"
       - name: "[bulid]"
         run: |
+          git config --global url."https://github.com/".insteadOf git@github.com:
+          git config --global url."https://".insteadOf git://
           yarn
           yarn build
 ...

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,8 +18,9 @@ jobs:
           repository: "${{ github.repository }}"
       - name: "[bulid]"
         run: |
-          git config --global url."https://github.com/".insteadOf git@github.com:
+          git config --global url."https://github.com/".insteadOf ssh://git@github.com/
           git config --global url."https://".insteadOf git://
+          git config --global url."https://".insteadOf ssh://
           yarn
           yarn build
 ...

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,14 +16,13 @@ jobs:
         uses: "actions/checkout@v2"
         with:
           repository: "${{ github.repository }}"
-          token: "${{ github.token }}"
           fetch-depth: 1
           clean: true
           lfs: false
-          persist-credentials: false
           submodules: false
       - name: "[bulid]"
         run: |
           yarn
+          yarn build
 ...
 # End of ci.yml

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,15 +8,21 @@ defaults:
   run:
     shell: "bash"
 jobs:
-  build:
-    name: "[ci|build]"
+  lint-test-build:
+    name: "[ci|lint-test-build]"
     runs-on: "ubuntu-18.04"
     steps:
-      - name: "[build|checkout] ${{ github.repository }} project"
+      - name: "[checkout] ${{ github.repository }} project"
         uses: "actions/checkout@v2"
         with:
           repository: "${{ github.repository }}"
-      - name: "[bulid]"
+      - name: "[lint]"
+        run: |
+          echo TBA some linting
+      - name: "[test]"
+        run: |
+          echo TBA some testing
+      - name: "[build]"
         run: |
           git config --global url."https://github.com/".insteadOf ssh://git@github.com/
           git config --global url."https://".insteadOf git://

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,10 +16,6 @@ jobs:
         uses: "actions/checkout@v2"
         with:
           repository: "${{ github.repository }}"
-          fetch-depth: 1
-          clean: true
-          lfs: false
-          submodules: false
       - name: "[bulid]"
         run: |
           yarn

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # org-roam-ui: an org-roam frontend
 
+[![ci](https://github.com/org-roam/org-roam-ui/actions/workflows/ci.yml/badge.svg)](https://github.com/org-roam/org-roam-ui/actions/workflows/ci.yml)
+
 ![image](https://user-images.githubusercontent.com/21983833/127746882-4ba00691-3be4-49d6-8c8c-e139a14596c2.png)
 
 Org-Roam-UI is a frontend for exploring and interacting with your [org-roam](https://github.com/org-roam/org-roam) notes.


### PR DESCRIPTION
This PR adds basic CI based on GitHub Actions providing free machine time to run any correspondent **lint**, **test**, **build** process on particular event.

* .github/workflows/ci.yml: new file
* README.md: add CI badge

**:NOTE:** When I try build it locally I noticed this issue:

```
warning package-lock.json found. Your project contains lock files generated by tools other than Yarn. 
It is advised not to mix package managers in order to avoid resolution inconsistencies caused by
 unsynchronized lock files. To clear this warning, remove package-lock.json.
```
Probably  it needs to be recreated with `yarn`