### PR TITLE
add follow method: local or global

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,7 +128,15 @@ Org-Roam-UI exposes a few variables, but most of the customization is done in th
 
 #### Following
 
-ORUI follows you around Emacs by default. To disable this, set
+ORUI follows you around Emacs in a local view by default.
+
+If you want to roam in a global graph, set
+
+```emacs-lisp
+(setq org-roam-ui-follow-method 'global)
+```
+
+To disable this, set
 
 ```emacs-lisp
 (setq org-roam-ui-follow nil)

--- a/README.md
+++ b/README.md
@@ -220,7 +220,7 @@ While we try to optimize the display of the graph, there is only so much we can 
 
 As much as it saddens us to say, Firefox's rendering engine is quite a bit slower than its Chromium cousins. Compare the performance of the two and see if that's the main issue first.
 
-#### Turn of the particles
+#### Turn off the particles
 
 I know, very cool to see those little guys travel up and down your notes, but very slow, especially in 3D mode.
 


### PR DESCRIPTION
Since I have 1w+ nodes, follow emacs in a global graph is low performance and not very useful.

I add a new variable `org-roam-ui-follow-method`. 

If this is set to `global`, it behaves like before;
If this is set to `local`, it will auto open the corresponding local graph of current node.