### PR TITLE
WIP: Infer the implied links represented in the org-mode hierarchy.

### DIFF
--- a/org-roam-ui.el
+++ b/org-roam-ui.el
@@ -317,6 +317,9 @@ unchanged."
                      /* Make sure the position of the child node is after the position of the parent, this stops cases where another node with the
                         same name as the parent is found later in the file. */
                      AND nodes.pos > N.pos
+                     /* Make sure the level of the parent node is less than the level of the current node, this avoid cases where there is a sibling
+                        node that has the same name as the parent, but appears closer (smaller pos_diff) to the actual node in the file. */
+                     AND N.level < nodes.level
                  )
                  /* Get the (src, dest) tuples for our links. */
                  SELECT results.src, results.dst


### PR DESCRIPTION
The hierarchical nature of org-mode can imply links between nested nodes
that are not explicitly represented in the org-roam db. This change uses
information in the db to infer these links, and adds them as links
denoted with the new "hierarchy" name.

The node properties we use for this are, olp the string representation
of the elisp list that represents the titles of headlines in the output
that make a path to this node, the title, the file, the level, and the
position.

Parent nodes are found by looking for their titles in the `olp` property
of a node in the same file. We ensure parents occur before the children
(filtering out later nodes with the same name). We also track the level
of parent, allowing us to select the most recent parent (highest level)
and the offset between the parent and the child. This lets us filter out
the previous headlines at the same level before the actual subtree this
node is in.

This is a large, complex sql query, but it does me that we do not need
to reparse any files or do any application level post-processing.

I added a `org-roam-ui-hierarchical-links` variable that controls if
these links appear or not.

This query also makes it possible to get links that have all nodes
pointing to their file node. This is done by changing the `MAX(level)`
aggregation to a `MIN(level)`. Is we wanted to make this customizable,
we could remove doing this in the UI level to streamline things.

Note: Currently the UI still still seems to highlight all nodes in a
file when you mouse over the file node, even if you have turned of the
`Link nodes with parent file` option. If this was powered by hierarchy
nodes from the backend, we could probably make fixing this behavior
easier.

This is the file I have been using to test, there are multiple nodes named Another, and if you don't handle the edge cases correctly, the link from `Real Note` would be drawn to the incorrect `Another` node.

```
:properties:
:ID:       53ef05aa-619d-473d-a6a2-35e1bd02c3cf
:end:
#+title: test
#+startup: latexpreview inlineimages

* Headline
:properties:
:ID:       1a2f111a-6b12-469c-b0b4-92a31d977b23
:end:
** Another :bad2:
:properties:
:ID:       a45cbf04-8e71-4c38-9ad4-f2dfa91eeb5b
:end:
** Another :good:
:properties:
:ID:       f11eecf0-bdcb-4124-803b-727e3aa9b70a
:end:
*** Another :bad3:
:properties:
:ID:       6dda2a88-445f-45a1-8c47-74941a8e8203
:end:
*** Real Note
:properties:
:ID:       667972fd-9711-4993-b38c-c5557607cdd2
:end:

** Second again
*** Real Note 2
:properties:
:ID:       3a7e34c9-0573-4b25-bc1a-10dc813be7a7
:end:
** Another :bad:
:properties:
:ID:       eecf45a0-03e9-4e73-8309-f19ae5d6c7db
:end:
```