### PR TITLE
Note opens in new window, if current isn't Roam

### DIFF
--- a/org-roam-ui.el
+++ b/org-roam-ui.el
@@ -175,13 +175,9 @@ This serves the web-build and API over HTTP."
                              (command (alist-get 'command msg))
                              (data (alist-get 'data msg)))
                 (cond ((string= command "open")
-                    (let ((should-open-in-new-window nil))
-                        (if (string-match "^[0-9]\\{14\\}-.*\.org$" (buffer-name))
-                                (setq should-open-in-new-window nil)
-                                (setq should-open-in-new-window t))
                         (org-roam-node-visit
                                 (org-roam-populate (org-roam-node-create
-                                :id (alist-get 'id data))) should-open-in-new-window)))
+                                :id (alist-get 'id data))) (not (org-roam-buffer-p))))
                       ((string= command "delete")
                        (progn
                        (message "Deleted %s" (alist-get 'file data))

--- a/org-roam-ui.el
+++ b/org-roam-ui.el
@@ -175,9 +175,13 @@ This serves the web-build and API over HTTP."
                              (command (alist-get 'command msg))
                              (data (alist-get 'data msg)))
                 (cond ((string= command "open")
-                    (org-roam-node-visit
-                        (org-roam-populate (org-roam-node-create
-                        :id (alist-get 'id data)))))
+                    (let ((should-open-in-new-window nil))
+                        (if (string-match "^[0-9]\\{14\\}-.*\.org$" (buffer-name))
+                                (setq should-open-in-new-window nil)
+                                (setq should-open-in-new-window t))
+                        (org-roam-node-visit
+                                (org-roam-populate (org-roam-node-create
+                                :id (alist-get 'id data))) should-open-in-new-window)))
                       ((string= command "delete")
                        (progn
                        (message "Deleted %s" (alist-get 'file data))


### PR DESCRIPTION
Fixes #82 

The problem appeared because in EXWM the browser application is also situated in an Emacs buffer. This led Org-roam to open the note on the active buffer, which was the browser, this way replacing it.

In my commit, I check if the current buffer name is corresponding to Org-Roam naming conventions, and if it does not, I  supply _org-roam-node-visit_ with the OTHER-WINDOW argument enabled. This leads org-roam to open the note in another window, (if you already have windows open with Roam buffers, it usually goes there), and if you're not using stuff like EXWM, than the package works as until now. 
There is a small caveat however: if, for example you're using GNOME and in your browser you have the UI open but at the moment your Emacs is focused on a buffer which does not display org-roam,  Emacs will not replace that buffer, but open a new window below it. 

I hope you're satisfied with the solution :)