### PR TITLE
fix: make follow-mode work with indirect buffers

### DIFF
--- a/org-roam-ui.el
+++ b/org-roam-ui.el
@@ -356,7 +356,7 @@ unchanged."
 
 (defun org-roam-ui--update-current-node ()
   "Send the current node data to the web-socket."
-  (when (and (websocket-openp oru-ws) (org-roam-buffer-p) (buffer-file-name))
+  (when (and (websocket-openp oru-ws) (org-roam-buffer-p) (buffer-file-name (buffer-base-buffer)))
   (let* ((node (org-roam-id-at-point)))
     (unless (string= org-roam-ui--ws-current-node node)
     (setq org-roam-ui--ws-current-node node)


### PR DESCRIPTION
Same as in `org-roam-buffer-p`, call `buffer-file-name` with
`buffer-base-buffer` which ensures that file name is determined
under all circumstances.