### PR TITLE
feat: add tags counters in filtering panel labels

### DIFF
--- a/components/Tweaks/TagColorPanel.tsx
+++ b/components/Tweaks/TagColorPanel.tsx
@@ -40,7 +40,7 @@ export const TagColorPanel = (props: TagColorPanelProps) => {
     <Box>
       <CUIAutoComplete
         items={tagArray}
-        label="Add tag to filter"
+        label={`Add tag to filter (${selectedItems.length}/${tagArray.length})`}
         placeholder=" "
         disableCreateItem={true}
         selectedItems={selectedItems}

--- a/components/Tweaks/TagPanel.tsx
+++ b/components/Tweaks/TagPanel.tsx
@@ -26,7 +26,7 @@ export const TagPanel = (props: TagPanelProps) => {
   return (
     <CUIAutoComplete
       items={tagArray}
-      label={'Add tag to ' + mode}
+      label={`Add tag to ${mode} (${selectedItems.length}/${tagArray.length})`}
       placeholder=" "
       onCreateItem={(item) => null}
       disableCreateItem={true}


### PR DESCRIPTION
Hello

This is a small improvement to display the number of filtered tags in the dedicated panels.

Here's what it looks like (I have 28 tags in my example) : 

![image](https://user-images.githubusercontent.com/39315/136388343-294d7789-9b69-4f9d-a837-93aa1af43555.png)
