### PR TITLE
Fix spelling of non-existant in filter settings

### DIFF
--- a/components/Tweaks/FilterPanel.tsx
+++ b/components/Tweaks/FilterPanel.tsx
@@ -132,7 +132,7 @@ const FilterPanel = (props: FilterPanelProps) => {
           ></Switch>
         </Flex>
         <Flex justifyContent="space-between">
-          <Text>Non-existant nodes</Text>
+          <Text>Non-existent nodes</Text>
           <Switch
             onChange={() => {
               setTagColors({ ...tagColors, bad: 'white' })


### PR DESCRIPTION
Something minor that I noticed in the screenshot of the readme. Do I also need to rebuild to `out` or how does it work? Doing yarn build gives me a build dir but not the out dir. Sorry I've never contributed here :sweat_smile: 