### PR TITLE
doc:(installation) package.el; no need to load 

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ org-roam-ui requires `org-roam`, `websocket`, `simple-httpd`, `f` and Emacs >= 2
 M-x package-install org-roam-ui
 ```
 
-There is further configuration is necessary when you use `packge.el` to install ORUI.
+No configuration is necessary when you use `packge.el` to install ORUI.
 
 ### Doom
 

--- a/README.md
+++ b/README.md
@@ -42,12 +42,7 @@ org-roam-ui requires `org-roam`, `websocket`, `simple-httpd`, `f` and Emacs >= 2
 M-x package-install org-roam-ui
 ```
 
-Load in Emacs (add to config):
-
-```lisp
-(add-to-list 'load-path "~/.emacs.d/private/org-roam-ui")
-(load-library "org-roam-ui")
-```
+There is further configuration is necessary when you use `packge.el` to install ORUI.
 
 ### Doom
 


### PR DESCRIPTION
As the main commands such as `org-roam-ui-mode` have `###autoload` cookie,
`package.el` takes care of `load-path` and autoloading by itself when a user
installs the package. I have tested this on my end. The minor mode command
appears in M-x and you can simply call it.