### PR TITLE
Add command to "collect" nodes

### DIFF
--- a/org-roam-ui.el
+++ b/org-roam-ui.el
@@ -37,6 +37,7 @@
 (require 'org-roam)
 (require 'org-roam-dailies)
 (require 'websocket)
+(require 'cl-lib) ;; for implicit cl-block around dolist
 
 (defgroup org-roam-ui nil
   "UI in Org-roam."
@@ -131,6 +132,15 @@ Defaults to #'browse-url."
   :group 'org-roam-ui
   :type 'function)
 
+(defcustom org-roam-ui-collect-function '((delve . delve-insert-nodes-by-id))
+  "Alist defining functions which collects nodes by passing their ids.
+The key is the name of the package which contains that function.
+The first package which is installed will be used.  The
+associated function must accept two arguments: A collection name
+and a list of node ids."
+  :group 'org-roam-ui
+  :type 'alist)
+
 ;;Hooks
 
 (defcustom org-roam-ui-before-open-node-functions nil
@@ -210,15 +220,28 @@ Takes _WS and FRAME as arguments."
                (websocket-frame-text frame) :object-type 'alist))
          (command (alist-get 'command msg))
          (data (alist-get 'data msg)))
-    (cond ((string= command "open")
-           (org-roam-ui--on-msg-open-node data))
-          ((string= command "delete")
-           (org-roam-ui--on-msg-delete-node data))
-          ((string= command "create")
-           (org-roam-ui--on-msg-create-node data))
-          (t
-           (message
+    (pcase command
+      ("open"     (org-roam-ui--on-msg-open-node data))
+      ("delete"   (org-roam-ui--on-msg-delete-node data))
+      ("create"   (org-roam-ui--on-msg-create-node data))
+      ("collect"  (org-roam-ui--on-msg-collect-node))
+      (_   (message
             "Something went wrong when receiving a message from org-roam-ui")))))
+
+(defun org-roam-ui--on-msg-collect-node (data)
+  "Add a node or nodes specified in DATA to a collection.
+Assumes DATA to be an alist with the following keys: `id',
+`collection'.  ID is a node ID or a list of IDs; COLLECTION is
+the name of the collection (a string).  Pass both arguments to
+the first available function found in
+`org-roam-ui-collect-function'."
+  (let* ((collection (alist-get 'collection data))
+         (ids        (alist-get 'id data)))
+    (or (pcase-dolist (`(,package-name . ,fn) org-roam-ui-collect-function)
+          (when (featurep package-name)
+            (funcall fn collection (if (listp ids) ids (list ids)))
+            (cl-return t)))
+        (error "No function defined for collecting nodes, see `org-roam-ui-collect-function'"))))
 
 (defun org-roam-ui--on-msg-open-node (data)
   "Open a node when receiving DATA from the websocket."


### PR DESCRIPTION
This is the proposed change for adding a "collection" function, the elisp-side. It introduces one new command verb, "collect", which is handeld in `org-roam-ui--on-msg-collect-node`.

Sorry for also merging the latest commits from the main branch before doing the PR, my changes are in the first commit.

I did not add yet anything for gathering the possible list of collections. There's a decision to be made. Currently, I see two possibilities: (a) just offer a list of open buffers holding collections; that would be simply a call to `delve-buffer-list`. (b) More powerful, offer a list of open buffers *and* a list of files. If the user chooses a file, it will be loaded into a buffer on the fly. That's what `Delve' does. I would have to write a function which offers that functionality.

I think (b) is more powerful and simply better, but it could mean that the web menu will offer quite a bit of choices. So that's mainly what was holding me back. If there's an elegant solution for that problem, I would adopt for (b).

Another thing: Currently "collecting" nodes adds the nodes in the background, leaving the current window configuration in Emacs as it is. That might be unitintuitive and could be turned into an option.
