### PR TITLE
Typo in variable name prevents filtering dailies out

### DIFF
--- a/org-roam-ui.el
+++ b/org-roam-ui.el
@@ -573,7 +573,7 @@ from all other links."
 
 (defun org-roam-ui--send-variables (ws)
   "Send miscellaneous org-roam variables through the websocket WS."
-    (let ((daily-dir (if (boundp 'org-roam-dailies-dir)
+    (let ((daily-dir (if (boundp 'org-roam-dailies-directory)
                          (if (file-name-absolute-p org-roam-dailies-directory)
                              (expand-file-name org-roam-dailies-directory)
                            (expand-file-name


### PR DESCRIPTION
Filtering dailies doesn't work for me, and this seems to be the reason.
There is no other instance of the name `org-roam-dailies-dir` in either `org-roam-ui` and `org-roam` itself, so we always get the default value `dailies/`, except on my config it's `daily/` (so, no nodes match the filter).

BTW, shouldn't `org-roam-ui` trust `org-roam` to be configured correctly, instead of trying so hard to get a value with logic that probably duplicates the variable declaration in `org-roam`?