### PR TITLE
Remove superfluous debug message

### DIFF
--- a/org-roam-ui.el
+++ b/org-roam-ui.el
@@ -584,7 +584,6 @@ from all other links."
                           org-attach-id-dir
                         (expand-file-name ".attach/" org-directory)))
           (sub-dirs (org-roam-ui-find-subdirectories)))
-      (message "im doing something")
       (websocket-send-text org-roam-ui-ws-socket
                            (json-encode
                             `((type . "variables")


### PR DESCRIPTION
This commit removes a debugging message that was being printed every time an
org-mode buffer in org-roam gets saved, obscuring potentially important
information in the minibuffer, and generally being annoying.