### PR TITLE
Fix error when retrieving the text for a citation node

### DIFF
--- a/org-roam-ui.el
+++ b/org-roam-ui.el
@@ -282,13 +282,15 @@ TODO: Be able to delete individual nodes."
       ((node (org-roam-populate (org-roam-node-create
                                  :id id)))
        (file (org-roam-node-file node)))
-    (org-roam-with-temp-buffer
+    (if (null file)
+      nil
+      (org-roam-with-temp-buffer
         file
-      (when (> (org-roam-node-level node) 0)
-        ;; Heading nodes have level 1 and greater.
-        (goto-char (org-roam-node-point node))
-        (org-narrow-to-element))
-      (buffer-substring-no-properties (buffer-end -1) (buffer-end 1)))))
+        (when (> (org-roam-node-level node) 0)
+          ;; Heading nodes have level 1 and greater.
+          (goto-char (org-roam-node-point node))
+          (org-narrow-to-element))
+        (buffer-substring-no-properties (buffer-end -1) (buffer-end 1))))))
 
 (defun org-roam-ui--send-text (id ws)
   "Send the text from org-node ID through the websocket WS."
@@ -300,7 +302,8 @@ TODO: Be able to delete individual nodes."
 
 (defservlet* node/:id text/plain ()
   "Servlet for accessing node content."
-  (insert (org-roam-ui--get-text (org-link-decode id)))
+  (let ((text (org-roam-ui--get-text (org-link-decode id))))
+    (if text (insert text)))
   (httpd-send-header t "text/plain" 200 :Access-Control-Allow-Origin "*"))
 
 (defservlet* img/:file text/plain ()

--- a/util/uniorg.tsx
+++ b/util/uniorg.tsx
@@ -42,7 +42,7 @@ export const UniOrg = (props: UniOrgProps) => {
       })
       .then((res) => {
         if (res === '') {
-          return '(empty node)'
+          setPreviewText('(empty node)')
         }
         if (res !== 'error') {
           console.log(res)


### PR DESCRIPTION
Citation nodes do not have text (they are not tied to a file and heading), so add a check to org-roam-ui--get-text for this. Also ensure that the preview text is updated even when it is empty.