### PR TITLE
fix: solve attach id not inherited from parents.

### DIFF
--- a/util/processOrg.tsx
+++ b/util/processOrg.tsx
@@ -77,6 +77,7 @@ export const ProcessedOrg = (props: ProcessedOrgProps) => {
     .use(extractKeywords)
     .use(attachments, {
       idDir: attachDir || undefined,
+      useInheritance: true
     })
     .use(uniorgSlug)
     .use(uniorg2rehype, { useSections: true })


### PR DESCRIPTION
Enabling inheritance for implies that attachment links will look through all parent headings until it finds the linked attachment.