### PR TITLE
Fix #225 

### DIFF
--- a/org-roam-ui.el
+++ b/org-roam-ui.el
@@ -184,6 +184,9 @@ This serves the web-build and API over HTTP."
     (setq httpd-root org-roam-ui-app-build-dir)
     (httpd-start)
     (setq org-roam-ui-ws-server
+          ; BUG this breaks when the theme is changed during a session,
+          ; then a new frame is created. Results in the frames crashing & the
+          ; default theme loading.
           (websocket-server
            35903
            :host 'local

--- a/org-roam-ui.el
+++ b/org-roam-ui.el
@@ -177,28 +177,26 @@ This serves the web-build and API over HTTP."
   :group 'org-roam-ui
   :init-value nil
   (cond
-   (org-roam-ui-mode
+   ((not org-roam-ui-mode)
    ;;; check if the default keywords actually exist on `orb-preformat-keywords'
    ;;; else add them
-     (setq-local httpd-port org-roam-ui-port)
-     (setq httpd-root org-roam-ui-app-build-dir)
-     (httpd-start)
-     (setq org-roam-ui-ws-server
-       (condition-case nil
-         (websocket-server
-           'org-roam-ui-port
+    (setq-local httpd-port org-roam-ui-port)
+    (setq httpd-root org-roam-ui-app-build-dir)
+    (httpd-start)
+    (setq org-roam-ui-ws-server
+          (websocket-server
+           35903
            :host 'local
            :on-open #'org-roam-ui--ws-on-open
            :on-message #'org-roam-ui--ws-on-message
-           :on-close #'org-roam-ui--ws-on-close)
-         (error (message (format "Error: Cannot launch org-roam-ui-server. Address already in use: %d" org-roam-ui-port)))))
-     (when org-roam-ui-open-on-start (org-roam-ui-open)))
-    (t
-      (progn
-        (websocket-server-close org-roam-ui-ws-server)
-        (httpd-stop)
-        (remove-hook 'after-save-hook #'org-roam-ui--on-save)
-        (org-roam-ui-follow-mode -1)))))
+           :on-close #'org-roam-ui--ws-on-close))
+    (when org-roam-ui-open-on-start (org-roam-ui-open)))
+   (t
+    (progn
+      (websocket-server-close org-roam-ui-ws-server)
+      (httpd-stop)
+      (remove-hook 'after-save-hook #'org-roam-ui--on-save)
+      (org-roam-ui-follow-mode -1)))))
 
 (defun org-roam-ui--ws-on-open (ws)
   "Open the websocket WS to org-roam-ui and send initial data."


### PR DESCRIPTION
Fix #225 by logging a soft error to the `*Messages*` buffer upon address collision for the `websocket-server` call within `org-roam-ui.el`.

