### PR TITLE
fix case where websocket collision crashes frames

### DIFF
--- a/org-roam-ui.el
+++ b/org-roam-ui.el
@@ -61,6 +61,11 @@
   35901
   "Port to serve the org-roam-ui interface.")
 
+(defcustom org-roam-ui-server-running nil
+  "If t, server is running. Used to prevent websockets collisions."
+  :group 'org-roam-ui
+  :type 'boolean)
+
 (defcustom org-roam-ui-sync-theme t
   "If true, sync your current Emacs theme with `org-roam-ui'.
 Works best with doom-themes.
@@ -177,26 +182,33 @@ This serves the web-build and API over HTTP."
   :group 'org-roam-ui
   :init-value nil
   (cond
-   (org-roam-ui-mode
+    ((and org-roam-ui-mode (not org-roam-ui-server-running))
+      (debug "org-roam-ui-mode server :: starting up...")
    ;;; check if the default keywords actually exist on `orb-preformat-keywords'
    ;;; else add them
-    (setq-local httpd-port org-roam-ui-port)
-    (setq httpd-root org-roam-ui-app-build-dir)
-    (httpd-start)
-    (setq org-roam-ui-ws-server
-          (websocket-server
-           35903
-           :host 'local
-           :on-open #'org-roam-ui--ws-on-open
-           :on-message #'org-roam-ui--ws-on-message
-           :on-close #'org-roam-ui--ws-on-close))
-    (when org-roam-ui-open-on-start (org-roam-ui-open)))
-   (t
-    (progn
-      (websocket-server-close org-roam-ui-ws-server)
-      (httpd-stop)
-      (remove-hook 'after-save-hook #'org-roam-ui--on-save)
-      (org-roam-ui-follow-mode -1)))))
+      (setq-local httpd-port org-roam-ui-port)
+      (setq httpd-root org-roam-ui-app-build-dir)
+      (httpd-start)
+      (setq org-roam-ui-ws-server
+        (ignore-errors (websocket-server
+                         35903
+                         :host 'local
+                         :on-open #'org-roam-ui--ws-on-open
+                         :on-message #'org-roam-ui--ws-on-message
+                         :on-close #'org-roam-ui--ws-on-close)))
+      (setq org-roam-ui-server-running t)
+      (when org-roam-ui-open-on-start (org-roam-ui-open)))
+    (org-roam-ui-mode
+      (message (format "org-roam-ui-server already runnning.")))
+    (t
+      (progn
+        (debug "org-roam-ui-mode server :: shutting down...")
+        (websocket-server-close org-roam-ui-ws-server)
+        (httpd-stop)
+        (setq org-roam-ui-server-running nil)
+        (remove-hook 'after-save-hook #'org-roam-ui--on-save)
+        (org-roam-ui-follow-mode -1)))))
+
 
 (defun org-roam-ui--ws-on-open (ws)
   "Open the websocket WS to org-roam-ui and send initial data."


### PR DESCRIPTION
**The Issue**

Mentioned in #202, there is a case where successive calls to enable org-roam-ui-mode causes an address collision due to the websocket-server call triggering with each request to activate the mode.

This appears to happen with `desktop.el` but can also be triggered with the following steps if using DOOM emacs, and emacs daemon.

1. Create new emacsclient frame: `emacsclient -c`
2. Enable org-roam-ui-mode
3. Change the theme

**Proposed solution**

This PR creates a new custom variable to track the state of the webserver: t if running & nil if not. A call to enable the mode only launches the websocket-server if the server is not already running. If the server was already running at the time of the call, log to the *Message* buffer that the server was already running. 

