### PR TITLE
org-roam-ui--update-theme now uses org-roam-ui-custom-theme when set

### DIFF
--- a/org-roam-ui.el
+++ b/org-roam-ui.el
@@ -568,7 +568,7 @@ from all other links."
               (setq ui-theme doom-theme))
           (setq ui-theme (org-roam-ui-get-theme)))
       (when org-roam-ui-custom-theme
-        org-roam-ui-custom-theme))
+		(setq ui-theme org-roam-ui-custom-theme)))
     ui-theme))
 
 


### PR DESCRIPTION
Fix bug where org-roam-ui--update-theme does not not set theme when org-roam-ui-custom-theme is set and org-roam-ui-sync-theme is nil