### PR TITLE
ENH: #259 Updating overflow prop on math/latex displays to be auto so scrollbars appear consistently between browsers.

### DIFF
--- a/components/Sidebar/noteStyle.ts
+++ b/components/Sidebar/noteStyle.ts
@@ -199,4 +199,8 @@ export const defaultNoteStyle = {
   '.footdef': { marginBottom: '1em' },
   '.figure': { padding: '1em' },
   '.figure p': { textAlign: 'center' },
+  '.math.math-display .katex': {
+    overflow: 'auto',
+    minHeight: '1.5em'
+  }
 }


### PR DESCRIPTION
Enhancement for #259 by updating overflow prop and also updates the default min height of math/latex to prevent vertical scrollbars from appearing by default for just a pixel or two of overflowed content.