### PR TITLE
ENH: #273 Adds readonly mode custom var to control deleting and creating nodes via org-roam-ui

### DIFF
--- a/components/contextmenu.tsx
+++ b/components/contextmenu.tsx
@@ -134,7 +134,7 @@ export const ContextMenu = (props: ContextMenuProps) => {
                 >
                   Open in Emacs
                 </MenuItem>
-              ) : (
+              ) : !readonlyMode && (
                 <MenuItem icon={<AddIcon />} onClick={() => createNodeInEmacs(target, webSocket)}>
                   Create node
                 </MenuItem>

--- a/components/contextmenu.tsx
+++ b/components/contextmenu.tsx
@@ -54,6 +54,7 @@ export default interface ContextMenuProps {
   target: OrgRoamNode | string | null
   nodeType?: string
   coordinates: { [direction: string]: number | undefined }
+  readonlyMode: boolean
   handleLocal: (node: OrgRoamNode, add: string) => void
   menuClose: () => void
   scope: { nodeIds: string[] }
@@ -71,6 +72,7 @@ export const ContextMenu = (props: ContextMenuProps) => {
     target,
     nodeType,
     coordinates,
+    readonlyMode,
     handleLocal,
     menuClose,
     scope,
@@ -183,7 +185,7 @@ export const ContextMenu = (props: ContextMenuProps) => {
               >
                 Preview
               </MenuItem>
-              {target?.level === 0 && (
+              {!readonlyMode && target?.level === 0 && (
                 <MenuItem
                   closeOnSelect={false}
                   icon={<DeleteIcon color="red.500" />}

--- a/org-roam-ui.el
+++ b/org-roam-ui.el
@@ -131,6 +131,12 @@ Defaults to #'browse-url."
   :group 'org-roam-ui
   :type 'function)
 
+(defcustom org-roam-ui-readonly-mode nil
+  "If true, 'org-roam-ui' will open in readonly mode, which currently
+disables the ability to permanently delete nodes"
+  :group 'org-roam-ui
+  :type 'boolean)
+
 ;;Hooks
 
 (defcustom org-roam-ui-before-open-node-functions nil
@@ -601,6 +607,8 @@ from all other links."
                                      ("useInheritance" .
                                       ,use-inheritance)
                                      ("roamDir" . ,org-roam-directory)
+                                     ("readonlyMode" .
+                                      ,org-roam-ui-readonly-mode)
                                      ("katexMacros" . ,org-roam-ui-latex-macros))))))))
 
 (defun org-roam-ui-sql-to-alist (column-names rows)

--- a/org-roam-ui.el
+++ b/org-roam-ui.el
@@ -132,8 +132,7 @@ Defaults to #'browse-url."
   :type 'function)
 
 (defcustom org-roam-ui-readonly-mode nil
-  "If true, 'org-roam-ui' will open in readonly mode, which currently
-disables the ability to permanently delete nodes"
+  "If true, 'org-roam-ui' will open in readonly mode."
   :group 'org-roam-ui
   :type 'boolean)
 
@@ -261,20 +260,22 @@ Takes _WS and FRAME as arguments."
   "Delete a node when receiving DATA from the websocket.
 
 TODO: Be able to delete individual nodes."
-  (progn
-    (message "Deleted %s" (alist-get 'file data))
-    (delete-file (alist-get 'file data))
-    (org-roam-db-sync)
-    (org-roam-ui--send-graphdata)))
+  (if (not org-roam-ui-readonly-mode)
+    (progn
+      (message "Deleted %s" (alist-get 'file data))
+      (delete-file (alist-get 'file data))
+      (org-roam-db-sync)
+      (org-roam-ui--send-graphdata))))
 
 (defun org-roam-ui--on-msg-create-node (data)
   "Create a node when receiving DATA from the websocket."
-  (progn
-    (if (and (fboundp #'orb-edit-note) (alist-get 'ROAM_REFS data))
+  (if (not org-roam-ui-readonly-mode)
+    (progn
+      (if (and (fboundp #'orb-edit-note) (alist-get 'ROAM_REFS data))
         (orb-edit-note (alist-get 'id data)))
-    (org-roam-capture-
-     :node (org-roam-node-create :title (alist-get 'title data))
-     :props '(:finalize find-file))))
+      (org-roam-capture-
+        :node (org-roam-node-create :title (alist-get 'title data))
+        :props '(:finalize find-file)))))
 
 (defun org-roam-ui--ws-on-close (_websocket)
   "What to do when _WEBSOCKET to org-roam-ui is closed."

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -85,6 +85,7 @@ export interface EmacsVariables {
   katexMacros?: { [key: string]: string }
   attachDir?: string
   useInheritance?: boolean
+  readonlyMode?: boolean
   subDirs: string[]
 }
 export type Tags = string[]
@@ -710,6 +711,7 @@ export function GraphPage() {
               target={contextMenuTarget}
               background={false}
               coordinates={contextPos}
+              readonlyMode={emacsVariables.readonlyMode || false}
               handleLocal={handleLocal}
               menuClose={contextMenu.onClose.bind(contextMenu)}
               webSocket={WebSocketRef.current}


### PR DESCRIPTION
Minor enhancement that adds a new custom variable `org-roam-ui-readonly-mode` as a boolean that can be used to disable certain features (currently only create and delete node). 

Controls showing the options in the UI as well as updating internal functions so these features cannot be called externally outside the UI when set to true/non-nil.