### PR TITLE
Allow byte-compilation when org-roam-dailies is missing.

### DIFF
--- a/org-roam-ui.el
+++ b/org-roam-ui.el
@@ -36,7 +36,6 @@
 (require 'simple-httpd)
 (require 'org-roam)
 (require 'websocket)
-(require 'org-roam-dailies)
 
 (defgroup org-roam-ui nil
   "UI in Org-roam."
@@ -571,7 +570,7 @@ from all other links."
 		(setq ui-theme org-roam-ui-custom-theme)))
     ui-theme))
 
-
+(defvar org-roam-dailies-directory)
 (defun org-roam-ui--send-variables (ws)
   "Send miscellaneous org-roam variables through the websocket WS."
     (let ((daily-dir (if (boundp 'org-roam-dailies-directory)


### PR DESCRIPTION
`org-roam-dailies` is an extension to `org-roam`, so `org-roam-ui` should be able to function without this extension (and byte-compile).

This tiny commit should allow this.