### PR TITLE
feat: save/load web-ui settings to local org-roam-dir

### DIFF
--- a/components/Tweaks/Storage/StoragePanel.tsx
+++ b/components/Tweaks/Storage/StoragePanel.tsx
@@ -1,0 +1,38 @@
+import {
+  Button,
+  VStack
+} from '@chakra-ui/react'
+import { saveStorage } from '../../../util/webSocketFunctions'
+
+export interface StoragePanelProps {
+  webSocket: any
+}
+
+export const StoragePanel = (props: StoragePanelProps) => {
+  const { webSocket } = props
+  return (
+    <VStack>
+      <Button onClick={() => {
+        saveStorage(JSON.stringify(localStorage), webSocket)
+      }}>Save Settings</Button>
+      <Button onClick={() => {
+        fetch(`http://localhost:35901/settings`)
+          .then((res) => {
+            return res.text()
+          })
+          .then((res) =>{
+            const settings = JSON.parse(res)
+            localStorage.clear()
+            for (const key in settings) {
+              localStorage.setItem(key, settings[key])
+            }
+            location.reload()
+          })
+          .catch((e) => {
+            console.log(e)
+            return 'Could not fetch the settings for some reason, sorry!'
+          })
+      }}>Load Settings</Button>
+    </VStack> 
+  )
+}

--- a/components/Tweaks/index.tsx
+++ b/components/Tweaks/index.tsx
@@ -33,6 +33,7 @@ import { usePersistantState } from '../../util/persistant-state'
 import { PhysicsPanel } from './Physics/PhysicsPanel'
 import { BehaviorPanel } from './Behavior/BehaviorPanel'
 import { VisualsPanel } from './Visual/VisualsPanel'
+import { StoragePanel } from './Storage/StoragePanel'
 
 export interface TweakProps {
   physics: typeof initialPhysics
@@ -54,6 +55,7 @@ export interface TweakProps {
   setColoring: any
   local: typeof initialLocal
   setLocal: any
+  webSocket: any
 }
 
 export const Tweaks = (props: TweakProps) => {
@@ -77,6 +79,7 @@ export const Tweaks = (props: TweakProps) => {
     setColoring,
     local,
     setLocal,
+    webSocket,
   } = props
 
   const [showTweaks, setShowTweaks] = usePersistantState('showTweaks', false)
@@ -226,6 +229,17 @@ export const Tweaks = (props: TweakProps) => {
                 setBehavior={setBehavior}
                 mouse={mouse}
                 setMouse={setMouse}
+              />
+            </AccordionPanel>
+          </AccordionItem>
+          <AccordionItem>
+            <AccordionButton>
+              <AccordionIcon marginRight={2} />
+              <Heading size="sm">Storage</Heading>
+            </AccordionButton>
+            <AccordionPanel>
+              <StoragePanel 
+                webSocket={webSocket}
               />
             </AccordionPanel>
           </AccordionItem>

--- a/org-roam-ui.el
+++ b/org-roam-ui.el
@@ -61,6 +61,10 @@
   35901
   "Port to serve the org-roam-ui interface.")
 
+(defvar org-roam-ui-web-settings-file-name
+  "./.org-roam-ui-web-settings"
+  "Filename for storing the settings from the browser.")
+
 (defcustom org-roam-ui-sync-theme t
   "If true, sync your current Emacs theme with `org-roam-ui'.
 Works best with doom-themes.
@@ -223,6 +227,8 @@ Takes _WS and FRAME as arguments."
            (org-roam-ui--on-msg-delete-node data))
           ((string= command "create")
            (org-roam-ui--on-msg-create-node data))
+          ((string= command "saveSettings")
+           (org-roam-ui--on-msg-save-settings data))
           (t
            (message
             "Something went wrong when receiving a message from org-roam-ui")))))
@@ -270,6 +276,13 @@ TODO: Be able to delete individual nodes."
      :node (org-roam-node-create :title (alist-get 'title data))
      :props '(:finalize find-file))))
 
+(defun org-roam-ui--on-msg-save-settings (data)
+  "Save settings from web ui to org-roam directory."
+  (with-temp-file
+      (expand-file-name org-roam-ui-web-settings-file-name org-roam-directory)
+    (insert data)))
+   
+
 (defun org-roam-ui--ws-on-close (_websocket)
   "What to do when _WEBSOCKET to org-roam-ui is closed."
   (remove-hook 'after-save-hook #'org-roam-ui--on-save)
@@ -308,6 +321,11 @@ TODO: Be able to delete individual nodes."
   (progn
     (httpd-send-file t (org-link-decode file))
     (httpd-send-header t "text/plain" 200 :Access-Control-Allow-Origin "*")))
+
+(defservlet* settings application/json ()
+  "Servlet for accessing the locally stored settings."
+  (insert-file-contents (expand-file-name org-roam-ui-web-settings-file-name org-roam-directory))
+  (httpd-send-header t "application/json" 200 :Access-Control-Allow-Origin "*"))
 
 (defun org-roam-ui--on-save ()
   "Send graphdata on saving an org-roam buffer.

--- a/org-roam-ui.el
+++ b/org-roam-ui.el
@@ -65,6 +65,9 @@
   "./.org-roam-ui-web-settings"
   "Filename for storing the settings from the browser.")
 
+(defvar org-roam-ui-autoload-settings t
+  "Automatically sends the settings to the ui when it is opened for the first time")
+
 (defcustom org-roam-ui-sync-theme t
   "If true, sync your current Emacs theme with `org-roam-ui'.
 Works best with doom-themes.
@@ -212,7 +215,9 @@ This serves the web-build and API over HTTP."
       (add-hook 'after-save-hook #'org-roam-ui--on-save))
     (message "Connection established with org-roam-ui")
     (when org-roam-ui-follow
-      (org-roam-ui-follow-mode 1))))
+      (org-roam-ui-follow-mode 1))
+    (when org-roam-ui-autoload-settings
+      (org-roam-ui--send-settings org-roam-ui-ws-socket))))
 
 (defun org-roam-ui--ws-on-message (_ws frame)
   "Functions to run when the org-roam-ui server receives a message.
@@ -322,7 +327,7 @@ TODO: Be able to delete individual nodes."
     (httpd-send-file t (org-link-decode file))
     (httpd-send-header t "text/plain" 200 :Access-Control-Allow-Origin "*")))
 
-(defservlet* settings application/json ()
+(defservlet settings application/json ()
   "Servlet for accessing the locally stored settings."
   (insert-file-contents (expand-file-name org-roam-ui-web-settings-file-name org-roam-directory))
   (httpd-send-header t "application/json" 200 :Access-Control-Allow-Origin "*"))
@@ -620,6 +625,19 @@ from all other links."
                                       ,use-inheritance)
                                      ("roamDir" . ,org-roam-directory)
                                      ("katexMacros" . ,org-roam-ui-latex-macros))))))))
+
+(defun org-roam-ui--send-settings (ws)
+  "Send the web-ui settings to the frontend through the websocket WS."
+  (let ((settings-file (expand-file-name org-roam-ui-web-settings-file-name org-roam-directory)))
+    (if (file-exists-p settings-file)
+        (websocket-send-text org-roam-ui-ws-socket
+                             (json-encode
+                              `((type . "settings")
+                                (data . ,(with-temp-buffer
+                                           (insert-file-contents settings-file)
+                                           (buffer-string)))))))))
+
+
 
 (defun org-roam-ui-sql-to-alist (column-names rows)
   "Convert sql result to alist for json encoding.

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -570,6 +570,7 @@ export function GraphPage() {
         overflow="clip"
       >
         <Tweaks
+          webSocket={WebSocketRef.current}
           {...{
             physics,
             setPhysics,

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -476,6 +476,31 @@ export function GraphPage() {
             default:
               return console.error('unknown message type', message.type)
           }
+        case 'settings': {
+          try {
+            const settings = JSON.parse(message.data)
+            if (settings['3d']) setThreeDim(JSON.parse(settings['3d'])); else setThreeDim(false);
+            if (settings.tagCols) setTagColors(JSON.parse(settings.tagCols)); else setTagColors({});
+            if (settings.physics) setPhysics(JSON.parse(settings.physics)); else setPhysics(initialPhysics);
+            if (settings.filter) setFilter(JSON.parse(settings.filter)); else setFilter(initialFilter);
+            if (settings.visuals) setVisuals(JSON.parse(settings.visuals)); else setVisuals(initialVisuals);
+            if (settings.behavior) setBehavior(JSON.parse(settings.behavior)); else setBehavior(initialBehavior);
+            if (settings.mouse) setMouse(JSON.parse(settings.mouse)); else setMouse(initialMouse);
+            if (settings.coloring) setColoring(JSON.parse(settings.coloring)); else setColoring(initialColoring);
+            if (settings.local) setLocal(JSON.parse(settings.local)); else setLocal(initialLocal);
+          } catch {
+            console.error("Error reading settings data. Reverting to default values.")
+            setThreeDim(false);
+            setTagColors({});
+            setPhysics(initialPhysics);
+            setFilter(initialFilter);
+            setVisuals(initialVisuals);
+            setBehavior(initialBehavior);
+            setMouse(initialMouse);
+            setColoring(initialColoring);
+            setLocal(initialLocal);
+          }
+        }
       }
     })
   }, [])

--- a/util/webSocketFunctions.ts
+++ b/util/webSocketFunctions.ts
@@ -5,6 +5,10 @@ export function sendMessageToEmacs(command: string, data: {}, webSocket: Reconne
     webSocket.send(JSON.stringify({ command: command, data: data }))
 }
 
+export function saveStorage(data: {}, webSocket: ReconnectingWebSocket) {
+    sendMessageToEmacs("saveSettings", data, webSocket)
+}
+
 export function getOrgText(node: OrgRoamNode, webSocket: ReconnectingWebSocket) {
     sendMessageToEmacs('getText', { id: node.id }, webSocket)
 }


### PR DESCRIPTION
Resolves #223 

This pull requests adds a small feature to save and load the graph settings from the web-ui into a file in the `org-roam-directory`.

It enables different different `org-roam` "silos" to store individual graph configurations (such as tag colours) and also allows easier synchronization of settings across browsers or devices.

To achieve this goal, I have added a section to the tweaks sidebar with buttons for manually saving and loading the configuration. (see `StoragePanel.tsx` ).

### Saving
The browsers local storage for `org-roam-ui` is copied into a JSON string and sent through the web-socket to the Emacs backend. It is then stored into a file in the current `org-roam-directory` (see `org-roam-ui--on-msg-save-settings`).

### Loading
The Emacs backend serves the content of the local settings file through a servlet. The frontend clears the current local storage for `org-roam-ui`, writes the content of the received settings file into the local storage and reloads the webpage (see `settings` servlet and `StoragePanel.tsx`).